### PR TITLE
Updates Nodes to allow creating & editing actions and triggers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ provided by `msg.namespace` and `msg.trigger` respectively.
 `msg.payload` should be an object of key-value pairs to pass to the trigger;
 any other type is ignored.
 
+### Create or edit a trigger
+
+The trigger node can be used to create new triggers or modify properties for
+existing ones.
+
+Fill in the service, namespace and trigger name in the edit dialog. The node will
+retrieve and display the current trigger properties from the OpenWhisk service.
+
+Selecting the "Allow Edits" checkbox will allow you to modify these properties.
+
+On deployment, the updated properties will be published to the OpenWhisk
+provider.
+
 ### Invoke an action
 
 The action node can be used to invoke an action and pass on the result in the flow.
@@ -46,3 +59,16 @@ The output message contains the following properties:
 
   - `payload` is the result of the action
   - `data` is the complete response object
+
+### Create or edit an action
+
+The action node can be used to create new actions or modify properties for
+existing ones.
+
+Fill in the service, namespace and action name in the edit dialog. The node will
+retrieve and display the current action source and properties from the OpenWhisk service.
+
+Selecting the "Allow Edits" checkbox will allow you to modify these properties.
+
+On deployment, the updated properties will be published to the OpenWhisk
+provider.

--- a/openwhisk/openwhisk.html
+++ b/openwhisk/openwhisk.html
@@ -31,7 +31,7 @@
 
 <script type="text/x-red" data-template-name="openwhisk-trigger">
 <div class="form-row">
-    <label for="node-input-namespace"><i class="fa fa-cloud"></i> Service</label>
+    <label for="node-input-service><i class="fa fa-cloud"></i> Service</label>
     <input type="text" id="node-input-service">
 </div>
 <div class="form-row">
@@ -40,8 +40,21 @@
 </div>
 <div class="form-row">
     <label for="node-input-trigger"><i class="fa fa-cog"></i> Trigger</label>
-    <input type="text" id="node-input-trigger">
+    <input type="text" style="width: 45%;" id="node-input-trigger">
+    <div style="display: inline-block; width: 95px; margin: 5px 35px 0 10px;">
+      <label for="node-input-edit" style="width: 75px;">Allow Edits</label>
+      <input type="checkbox" id="node-input-edit" style="width: 14px; margin-top: 0px;">
+    </div>
 </div>
+
+<div class="form-row trigger-source" style="display: none;">
+  <label><i class="fa fa-list"></i> Parameters</label>
+  <input type="hidden" id="node-input-parameters" autofocus="autofocus">
+</div>
+<div class="form-row node-input-parameters-container-row trigger-source" style="display: none;">
+  <ol id="node-input-parameters-container"></ol>
+</div>
+
 <div class="form-row">
     <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
     <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
@@ -59,12 +72,37 @@
 </div>
 <div class="form-row">
     <label for="node-input-action"><i class="fa fa-cog"></i> Action</label>
-    <input type="text" id="node-input-action">
+    <input type="text"  style="width: 45%" id="node-input-action">
+    <div style="display: inline-block; width: 95px; margin: 5px 35px 0 10px;">
+      <label for="node-input-edit" style="width: 75px;">Allow Edits</label>
+      <input type="checkbox" id="node-input-edit" style="width: 14px; margin-top: 0px;">
+  </div>
 </div>
+
+<div class="form-row action-source" style="display: none;">
+  <label><i class="fa fa-list"></i> Parameters</label>
+  <input type="hidden" id="node-input-parameters" autofocus="autofocus">
+</div>
+<div class="form-row node-input-parameters-container-row action-source" style="display: none;">
+  <ol id="node-input-parameters-container"></ol>
+</div>
+<div class="form-row action-source" style="margin-bottom: 0px; display: none;">
+  <label for="node-input-func" style="width: 200px;">
+    <i class="fa fa-wrench"></i> Action Source
+    </label>
+  <input type="hidden" id="node-input-func" autofocus="autofocus">
+  <input type="hidden" id="node-input-noerr">
+</div>
+
+<div class="form-row node-text-editor-row action-source" style="display: none;">
+  <div style="height: 250px;" class="node-text-editor" id="node-input-func-editor" ></div>
+</div>
+
 <div class="form-row">
     <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
     <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
 </div>
+
 </script>
 
 <script type="text/x-red" data-help-name="openwhisk-service"></script>
@@ -111,7 +149,9 @@ action; any other type is ignored.</p>
             name: { value: "" },
             namespace: { value: "" },
             trigger: { value: "" },
-            service: { type:"openwhisk-service", required: true }
+            service: { type:"openwhisk-service", required: true },
+            params: { value: [{key: "", value: "", disabled: true}] },
+            edit: { value: false }
         },
         align: "right",
         inputs: 1,
@@ -121,22 +161,254 @@ action; any other type is ignored.</p>
         paletteLabel:"OpenWhisk",
         label: function() {
             return this.name || this.trigger ||  "Trigger";
-        }
+        },
+        oneditprepare: function () {
+          $("#node-input-parameters-container").editableList({
+            removable: true,
+            addItem: addItem
+          });
+
+          this.params.forEach(function (param) {
+            $("#node-input-parameters-container").editableList('addItem', param);
+          });
+
+          if (this.edit) {
+              $('.trigger-source').show();
+          } else if (this.trigger && this.namespace && this.service) {
+              retrieveTriggerSource(this);
+          }
+
+          var that = this;
+          $('#node-input-trigger').keyup(function () {
+            clearTimeout(that.timeout);
+            that.timeout = setTimeout(function () {
+              retrieveTriggerSource(that);
+            }, 500);
+          });
+
+          $("#node-input-edit").change(function () {
+            var checked = $("#node-input-edit").prop("checked");
+            if (checked) {
+              makeParametersReadOnly(false);
+            } else {
+              retrieveTriggerSource(that);
+            }
+          });
+
+          makeParametersReadOnly(true);
+        },
+        oneditsave: function () {
+          var checked = $("#node-input-edit").prop("checked");
+          if (checked) {
+            var params = [];
+            $(".red-ui-editableList li").each(function (idx, li) {
+              var key = $(li).find(".params-key").val();
+              var value = $(li).find(".params-value").val();
+              params.push({key: key, value: value}); 
+            })
+            this.params = params;
+          } else {
+            this.params = [{disabled: true}];
+          }
+        },
+
     });
+
+    function makeParametersReadOnly(readOnly) {
+      $(".red-ui-editableList input").prop('disabled', readOnly);
+      if (readOnly) {
+        $(".red-ui-editableList .editor-button").hide();
+      } else {
+        $(".red-ui-editableList .editor-button").show();
+      }
+    }
+
+    function makeActionReadOnly(editor, readOnly) {
+      editor.setOptions({
+        readOnly: readOnly,
+        highlightActiveLine: !readOnly,
+        highlightGutterLine: !readOnly 
+      });
+      editor.renderer.$cursorLayer.element.style.opacity = readOnly ? 0 : 1;
+      makeParametersReadOnly(readOnly);
+    }
+
+    function retrieveActionSource(node) {
+      var action = $('#node-input-action').val();
+      var namespace = $('#node-input-namespace').val();
+      var service = RED.nodes.node($("#node-input-service").val());
+
+      if (!action || !namespace || !service) return;
+      $('.action-source').show();
+      $(".fa-cog").addClass("fa-spin")
+
+      var url = "openwhisk-action/?action=" + action + "&namespace=" + namespace; 
+      // if the user has defined the service before deploying, send the credentials.
+      // otherwise, send the service identifier.
+      if (service.credentials && service.credentials.has_key) {
+        url += "&key=" + service.credentials.key + "&api=" + service.api;
+      } else {
+        url += "&id=" + service.id;
+      }
+
+      $.getJSON(url)
+        .done(function (result) {
+          node.editor.setValue(result.exec.code);
+          node.editor.clearSelection();
+          $("#node-input-edit").prop("checked", false);
+          $(".fa-cog").removeClass("fa-spin")
+          $("#node-input-parameters-container").editableList('empty');
+          var parameters = result.parameters || [];
+          if (!parameters.length) parameters.push({});
+          parameters.forEach(function (param) {
+            param.disabled = true;
+            $("#node-input-parameters-container").editableList('addItem', param);
+          });
+          makeActionReadOnly(node.editor, true);
+        })
+        .fail(function () {
+          $('.action-source').hide();
+          $(".fa-cog").removeClass("fa-spin")
+        });
+    };
+
+    function retrieveTriggerSource(node) {
+      var action = $('#node-input-trigger').val();
+      var namespace = $('#node-input-namespace').val();
+      var service = RED.nodes.node($("#node-input-service").val());
+
+      if (!action || !namespace || !service) return;
+      $('.trigger-source').show();
+      $(".fa-cog").addClass("fa-spin")
+
+      var url = "openwhisk-trigger/?trigger=" + action + "&namespace=" + namespace; 
+      if (service.credentials && service.credentials.has_key) {
+        url += "&key=" + service.credentials.key + "&api=" + service.api;
+      } else {
+        url += "&id=" + service.id;
+      }
+
+      $.getJSON(url)
+        .done(function (result) {
+          $("#node-input-edit").prop("checked", false);
+          $(".fa-cog").removeClass("fa-spin")
+          $("#node-input-parameters-container").editableList('empty');
+          var parameters = result.parameters || [];
+          if (!parameters.length) parameters.push({});
+          parameters.forEach(function (param) {
+            param.disabled = true;
+            $("#node-input-parameters-container").editableList('addItem', param);
+          });
+          makeParametersReadOnly(true);
+        })
+        .fail(function () {
+          $('.trigger-source').hide();
+          $(".fa-cog").removeClass("fa-spin")
+        });
+    }
+
+    var addItem = function (row, index, data) {
+      var key = data.key || "";
+      var value = data.value || "";
+      var disabled = data.disabled ? "disabled" : "";
+      var template = '<i style="color: #eee; margin-left:15px;" class="fa fa-bars"></i><input class="params-key" style="width: 40%; margin-left: 15px;" '+disabled+' type="text" placeholder="key" value="'+key+'"><input class="params-value" style="width: 40%; margin-left: 15px;" '+disabled+' type="text" placeholder="value" value="'+value+'">';
+      $(row).html(template);
+    }; 
 
     RED.nodes.registerType('openwhisk-action', {
         category: 'function',
         defaults: {
             name: { value: "" },
+            func: {value:""},
             namespace: { value: "" },
             action: { value: "" },
-            service: { type:"openwhisk-service", required: true }
+            params: { value: [{key: "", value: "", disabled: true}] },
+            service: { type:"openwhisk-service", required: true },
+            edit: { value: false }
         },
         inputs: 1,
         outputs: 1,
         color: "#6C9FC3",
         icon: "openwhisk.png",
         paletteLabel:"OpenWhisk",
+        oneditprepare: function () {
+          $("#node-input-parameters-container").editableList({
+            removable: true,
+            addItem: addItem
+          });
+
+          this.params.forEach(function (param) {
+            $("#node-input-parameters-container").editableList('addItem', param);
+          });
+          // if node configuration includes custom action source,
+          // show the editor panel straight away.
+          if (this.edit) {
+              $('.action-source').show();
+          // otherwise, if we have the correct parameters, retrieve it
+          // from the platform.
+          } else if (this.action && this.namespace && this.service) {
+              retrieveActionSource(this);
+          }
+
+          var that = this;
+          // whenever action name changes, update Action source.
+          // debounce events to half a second.
+          $('#node-input-action').keyup(function () {
+            clearTimeout(that.timeout);
+            that.timeout = setTimeout(function () {
+              retrieveActionSource(that);
+            }, 500);
+          });
+
+          // when user swaps back to non-edit mode,
+          // retrieve current action source from openwhisk. 
+          // otherwise, take editor out of readonly mode.
+          $("#node-input-edit").change(function () {
+            var checked = $("#node-input-edit").prop("checked");
+            if (checked) {
+              makeActionReadOnly(that.editor, false);
+              that.editor.focus();
+            } else {
+              retrieveActionSource(that);
+            }
+          });
+
+          this.editor = RED.editor.createEditor({
+            id: 'node-input-func-editor',
+            mode: 'ace/mode/javascript',
+            value: $("#node-input-func").val()
+          });
+          makeActionReadOnly(this.editor, true);
+        },
+        oneditsave: function () {
+            var annot = this.editor.getSession().getAnnotations();
+            this.noerr = 0;
+            $("#node-input-noerr").val(0);
+            for (var k=0; k < annot.length; k++) {
+                if (annot[k].type === "error") {
+                    $("#node-input-noerr").val(annot.length);
+                    this.noerr = annot.length;
+                }
+            }
+            // if user has decided to allow source modifications, store the 
+            // function definition within the node. otherwise, wipe it out 
+            // so we can retrieve it from the API next time...
+            var checked = $("#node-input-edit").prop("checked");
+            if (checked) {
+              $("#node-input-func").val(this.editor.getValue());
+              var params = []
+              $(".red-ui-editableList li").each(function (idx, li) {
+                var key = $(li).find(".params-key").val();
+                var value = $(li).find(".params-value").val();
+                params.push({key: key, value: value}); 
+              })
+              this.params = params;
+            } else {
+              $("#node-input-func").val("");
+              this.params = [{disabled: true}];
+            }
+            delete this.editor;
+        },
         label: function() {
             return this.name || this.action ||  "Action";
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-openwhisk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A set of nodes for interacting with IBM Bluemix OpenWhisk",
   "license": "Apache",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-    "name": "node-red-node-openwhisk",
-    "version": "0.1.1",
-    "description": "A set of nodes for interacting with IBM Bluemix OpenWhisk",
-    "license": "Apache",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/node-red/node-red-node-openwhisk.git"
-    },
-    "keywords": [
-        "node-red",
-        "openwhisk"
-    ],
-    "node-red": {
-        "nodes": {
-            "openwhisk": "openwhisk/openwhisk.js"
-        }
-    },
-    "contributors": [
-        "Nick O'Leary <nick.oleary@gmail.com>"
-    ],
-    "dependencies": {
-        "request": "2.69.*"
+  "name": "node-red-node-openwhisk",
+  "version": "0.2.0",
+  "description": "A set of nodes for interacting with IBM Bluemix OpenWhisk",
+  "license": "Apache",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/node-red/node-red-node-openwhisk.git"
+  },
+  "keywords": [
+    "node-red",
+    "openwhisk"
+  ],
+  "node-red": {
+    "nodes": {
+      "openwhisk": "openwhisk/openwhisk.js"
     }
+  },
+  "contributors": [
+    "Nick O'Leary <nick.oleary@gmail.com>"
+  ],
+  "dependencies": {
+    "openwhisk": "^2.1.3"
+  }
 }


### PR DESCRIPTION
Numerous updates to the nodes to support editing and creating
Actions and Triggers from within Node-RED. Users can now view
more details from the resource definitions and modify those properties.
This also allows them to create new Actions & Triggers.

UI has been modified to support these features.

Nodes now use the OpenWhisk SDK to make API calls, rather than handling
this manually.